### PR TITLE
Allow passing of block to `sign_user_in_or_render`

### DIFF
--- a/lib/simplest_auth/sessions_controller.rb
+++ b/lib/simplest_auth/sessions_controller.rb
@@ -56,6 +56,8 @@ module SimplestAuth
       if @session.valid?
         send("current_#{user_type_to_persist}=", @session.user)
 
+        after_sign_in
+
         self.flash[:notice] = message
         redirect_to redirect_url
       else
@@ -75,6 +77,10 @@ module SimplestAuth
 
     def session_class
       self.class.session_class_name.constantize
+    end
+    
+    def after_sign_in
+      # NOOP: override in inheriting class if necessary
     end
 
   end

--- a/spec/lib/sessions_controller_spec.rb
+++ b/spec/lib/sessions_controller_spec.rb
@@ -115,6 +115,13 @@ describe SimplestAuth::SessionsController do
           subject.create
         end
 
+        it "calls the :after_sign_in hook" do
+          new_session.stub(:user)
+
+          subject.should_receive(:after_sign_in).with()
+          subject.create
+        end
+
         it "sets the flash" do
           flash = double('flash')
           flash.should_receive(:[]=).with(:notice, 'You have signed in successfully')
@@ -137,6 +144,13 @@ describe SimplestAuth::SessionsController do
         before do
           new_session.stub(:valid?).with().and_return(false)
           ::Session.stub(:new).and_return(new_session)
+        end
+
+        it "does not call the :after_sign_in hook" do
+          new_session.stub(:user)
+
+          subject.should_receive(:after_sign_in).never
+          subject.create
         end
 
         it "renders" do


### PR DESCRIPTION
In order to allow additional actions to take place after a user signs
in, a block can be passed to this method that will be executed on
successful login.
